### PR TITLE
task8-fix sql bug

### DIFF
--- a/app/models/place.rb
+++ b/app/models/place.rb
@@ -17,5 +17,5 @@ class Place < ApplicationRecord
   scope :order_by_rating, ->{left_joins(:bookings).order rating: :desc}
   scope :location, ->(district_id){where location_id: district_id}
   scope :max_guests, ->(guests){where("max_guests >= ?", guests)}
-  scope :available_room, ->(check_in, check_out){where(Settings.query.available_room, check_in, check_out)}
+  scope :select_place, ->{select("bookings.check_in_date,bookings.check_out_date , places.*")}
 end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -13,5 +13,3 @@ validations:
     password_maxlength: 15
 pagination:
   per_page: 20
-query:
-  available_room: "bookings.check_in_date IS NULL OR bookings.check_out_date < ? OR ? < bookings.check_in_date"


### PR DESCRIPTION
có 1 vấn đề là vd nếu truyền lên  @check_in_date.in_time_zone thì khi minh chỉ truyền y/m/d thì mặc định giờ nó cho là 0h.
<br>
Nếu so sánh cùng 1 ngày
 ```ruby
  place.check_out_date.in_time_zone < @check_in_date.in_time_zone
 ``` 
thì 
(```place.check_out_date.in_time_zone```  thằng này có giờ rõ ràng vd 3 4h) nên cái bt so sánh kia gần như là false 

**Do đó t nghĩ là phải cách 1 ngày mới cho thuê được**
